### PR TITLE
Add workaround for no return warning on Windows in licenseNotice function

### DIFF
--- a/src/lib/synergy/gui/license/license_notices.cpp
+++ b/src/lib/synergy/gui/license/license_notices.cpp
@@ -37,6 +37,7 @@ QString licenseNotice(const License &license)
     return subscriptionLicenseNotice(license);
   } else {
     qFatal("license notice only for time limited licenses");
+    return ""; // Workaround for no return warning on Windows.
   }
 }
 


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1995