### PR TITLE
Allow personal licenses to work offline

### DIFF
--- a/src/lib/synergy/gui/ActivationDialog.cpp
+++ b/src/lib/synergy/gui/ActivationDialog.cpp
@@ -27,6 +27,7 @@
 #include "ui_ActivationDialog.h"
 
 #include <QApplication>
+#include <QFontDatabase>
 #include <QMessageBox>
 #include <QScreen>
 #include <QStyle>
@@ -48,6 +49,7 @@ ActivationDialog::ActivationDialog(QWidget *parent, AppConfig &appConfig, Licens
   m_ui->setupUi(this);
 
   m_ui->m_pLabelNotice->setStyleSheet(kStyleNoticeLabel);
+  m_ui->m_pTextEditSerialKey->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
   refreshSerialKey();
 }

--- a/src/lib/synergy/gui/ActivationDialog.ui
+++ b/src/lib/synergy/gui/ActivationDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>541</width>
-    <height>241</height>
+    <height>330</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,10 @@
    <item>
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>&lt;p&gt;Your serial key is on your &lt;a href=&quot;https://symless.com/synergy/account?source=gui&quot; style=&quot;color:#4285f4;&quot;&gt;account&lt;/span&gt;&lt;/a&gt; page. Don't have a license? &lt;a href=&quot;https://symless.com/synergy/contact?source=gui&quot; style=&quot;color:#4285f4;&quot;&gt;Contact us&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</string>
+      <string>&lt;p&gt;Your serial key is on your &lt;a href=&quot;https://symless.com/synergy/account?utm_source=gui-s1&quot; style=&quot;color:#4285f4;&quot;&gt;account&lt;/a&gt; page.&lt;br/&gt;Don't have a license? &lt;a href=&quot;https://symless.com/synergy/contact?utm_source=gui-s1&quot; style=&quot;color:#4285f4;&quot;&gt;Contact us&lt;/a&gt; or &lt;a href=&quot;https://symless.com/synergy/purchase?utm_source=gui-s1&quot; style=&quot;color:#4285f4;&quot;&gt;purchase&lt;/a&gt; today.&lt;/p&gt;&lt;p&gt;Using Synergy on an offline or air-gapped network?&lt;br/&gt;Offline serial keys are &lt;a href=&quot;https://symless.com/synergy/contact?utm_source=gui-s1&quot; style=&quot;color:#4285f4;&quot;&gt;available on request&lt;/a&gt;.&lt;/p&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>
@@ -38,21 +41,8 @@
    </item>
    <item>
     <widget class="QTextEdit" name="m_pTextEditSerialKey">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
      <property name="tabChangesFocus">
       <bool>true</bool>
-     </property>
-     <property name="html">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="acceptRichText">
       <bool>false</bool>

--- a/src/lib/synergy/gui/CancelActivationDialog.ui
+++ b/src/lib/synergy/gui/CancelActivationDialog.ui
@@ -17,7 +17,7 @@
    <item alignment="Qt::AlignmentFlag::AlignTop">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You'll need to purchase a license to use Synergy.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://symless.com/synergy/contact?source=gui&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;Contact us&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The application will now exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You'll need to purchase a license to use Synergy.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://symless.com/synergy/contact?utm_source=gui-s1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;Contact us&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The application will now exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/lib/synergy/gui/constants.h
+++ b/src/lib/synergy/gui/constants.h
@@ -28,7 +28,7 @@ const auto kBusinessProductName = "Synergy 1 Business";
 
 const auto kUrlApi = "https://symless.com/api";
 const auto kUrlWebsite = DESKFLOW_WEBSITE_URL;
-const auto kUrlSourceQuery = "source=gui";
+const auto kUrlSourceQuery = "utm_source=gui-s1";
 
 const auto kLinkBuy = R"(<a href="%1" style="color: %2">Buy now</a>)";
 const auto kLinkRenew = R"(<a href="%1" style="color: %2">Renew now</a>)";

--- a/src/lib/synergy/gui/license/LicenseHandler.cpp
+++ b/src/lib/synergy/gui/license/LicenseHandler.cpp
@@ -521,6 +521,21 @@ void LicenseHandler::runRemoteCheck()
     return;
   }
 
+  // Personal licenses activate once and are never re-validated, so they keep working on
+  // offline and restricted networks. Only business licenses are re-checked.
+  if (m_license.productEdition() != Product::Edition::kBusiness) {
+    if (isInGracePeriod()) {
+      // Nothing else clears grace once personal checks stop, and a stale grace flag
+      // suppresses the renew nag forever.
+      qInfo("clearing stale grace period for personal license");
+      m_settings.setGraceStartEpochSecs(0);
+      m_settings.sync();
+      m_warnedAboutGrace = false;
+    }
+    qDebug("personal license, skipping remote check");
+    return;
+  }
+
   if (m_apiClient.isBusy()) {
     qDebug("license activator busy, skipping remote check");
     return;


### PR DESCRIPTION
Personal licenses activate once and are no longer re-checked remotely,
so they keep working on offline and air-gapped networks. Business
licenses are still validated as before. A stale grace period left over
from earlier remote checks is cleared so the renew notice doesn't
linger.

The activation dialog now mentions that offline serial keys are
available on request, gives long keys more room and a fixed-width
font, and links to the purchase page. GUI link tracking now uses
utm_source=gui-s1.